### PR TITLE
Pin octodns to PyPi-released version

### DIFF
--- a/all/requirements.txt
+++ b/all/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/octodns/octodns@2d865b62c3bcab2edce16a30078bac862a0b9224#egg=octodns
+octodns==0.9.16
 octodns-azure==0.0.3
 octodns-cloudflare==0.0.1
 octodns-constellix==0.0.2


### PR DESCRIPTION
0.9.16 is the latest version: https://pypi.org/project/octodns/#history

I'm not sure what the current status of the migration is to separate modules, so happy to wait to pin to PyPi version. So far, we've been tracking a SHA-1 of the octodns/octodns repo.