### PR TITLE
Publish 'octodns' (all) flavor in GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 99
-  
+

--- a/.github/workflows/publish-on-push-to-main.yml
+++ b/.github/workflows/publish-on-push-to-main.yml
@@ -287,6 +287,24 @@ jobs:
         DOCKER_REGISTRY_URL: docker.io
       name: Docker Logout
       run: docker logout "$DOCKER_REGISTRY_URL"
+  Publish_octodns:
+    name: octodns
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - env:
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        DOCKER_REGISTRY_URL: docker.io
+        DOCKER_USERNAME: octodns
+      name: Docker Login
+      run: bash -c 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        "$DOCKER_REGISTRY_URL"'
+    - name: Publish octodns
+      run: script/release octodns octodns/octodns
+    - env:
+        DOCKER_REGISTRY_URL: docker.io
+      name: Docker Logout
+      run: docker logout "$DOCKER_REGISTRY_URL"
   Publish_ovh:
     name: ovh
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: script/cibuild ns1 ns1
+  Test_octodns:
+    name: octodns
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/cibuild octodns octodns
   Test_ovh:
     name: ovh
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This runs `octodns-sync` on the contents of the current working directory.
 | hetzner | [octodns_hetzner](https://github.com/octodns/octodns-hetzner) | [octodns/hetzner](https://hub.docker.com/r/octodns/hetzner) |
 | mythicbeasts | [octodns_mythicbeasts](https://github.com/octodns/octodns-mythicbeasts) | [octodns/mythicbeasts](https://hub.docker.com/r/octodns/mythicbeasts) |
 | ns1 | [octodns_ns1](https://github.com/octodns/octodns-ns1) | [octodns/ns1](https://hub.docker.com/r/octodns/ns1) |
+| octodns (all) | [octodns](https://github.com/octodns/octodns) | [octodns/octodns](https://hub.docker.com/r/octodns/octodns) |
 | ovh | [octodns_ovh](https://github.com/octodns/octodns-ovh) | [octodns/ovh](https://hub.docker.com/r/octodns/ovh) |
 | powerdns | [octodns_powerdns](https://github.com/octodns/octodns-powerdns) | [octodns/powerdns](https://hub.docker.com/r/octodns/powerdns) |
 | rackspace | [octodns_rackspace](https://github.com/octodns/octodns-rackspace) | [octodns/rackspace](https://hub.docker.com/r/octodns/rackspace) |

--- a/script/generate-workflow-files
+++ b/script/generate-workflow-files
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 
-import yaml
+import sys
+
+try:
+    import yaml
+except ModuleNotFoundError:
+    sys.exit("fatal: pyyaml missing. install with 'pip3 install pyyaml'")
 
 def image_name(flavor):
     if flavor == 'all':
@@ -54,13 +59,18 @@ def print_markdown_table(flavors):
     print('| Flavor | Module | Docker Hub |')
     print('|--------|--------|------------|')
     for flavor in flavors:
-        print(f'| {flavor} | [octodns_{flavor}](https://github.com/octodns/octodns-{flavor}) | [octodns/{image_name(flavor)}](https://hub.docker.com/r/octodns/{image_name(flavor)}) |')
+        if flavor == "octodns":
+            print(f'| {flavor} (all) | [octodns](https://github.com/octodns/octodns) | [octodns/{image_name(flavor)}](https://hub.docker.com/r/octodns/{image_name(flavor)}) |')
+        else:
+            print(f'| {flavor} | [octodns_{flavor}](https://github.com/octodns/octodns-{flavor}) | [octodns/{image_name(flavor)}](https://hub.docker.com/r/octodns/{image_name(flavor)}) |')
 
 def main():
     with open('all/requirements.txt', 'r', encoding='UTF-8') as file:
         flavors = [line.rstrip() for line in file.readlines()]
         flavors.pop(0)
         flavors = [flavor.split('==')[0].split('-')[1] for flavor in flavors]
+    flavors.append("octodns")
+    flavors.sort()
     print(flavors)
     write_test_workflow(flavors)
     write_publish_workflow(flavors)


### PR DESCRIPTION
Fixes #27.

The `octodns/octodns` image hasn't been pushed automatically since the introduction of `script/generate-workflow-files` since it auto-generates from the `octodns-SUFFIX` lines in `all/requirements.txt`. I forgot to add this omnibus flavor in manually.