### PR TITLE
dependabot: add docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,9 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 99
+- package-ecosystem: docker
+  directory: "/all"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 99
 


### PR DESCRIPTION
this would update the python version used in all the images without us having to keep track of python releases