### PR TITLE
script/release: fix improper quoting

### DIFF
--- a/script/release
+++ b/script/release
@@ -17,7 +17,7 @@ test -z "$TAG" && {
     echo "usage: $0 <FLAVOR> <FULL_TAG>"
     exit 1
 }
-TAG="${TAG}:"$(date +"%Y.%m")"
+TAG="${TAG}:$(date +"%Y.%m")"
 
 set -ex
 


### PR DESCRIPTION
This caused the release Actions workflows to fail.