### PR TITLE
Pushing YYYY.MM tags again

### DIFF
--- a/.github/workflows/publish-on-push-to-main.yml
+++ b/.github/workflows/publish-on-push-to-main.yml
@@ -18,11 +18,9 @@ jobs:
         images: octodns/${{matrix.flavor}}
         labels: org.opencontainers.image.documentation=https://github.com/octodns/octodns#readme
           org.opencontainers.image.licenses=MIT
-        tags: |
-          # monthly tagged release
-          type=raw,value={{date 'YYYY.MM'}},enable={{is_default_branch}}
-          # 'latest' tag if on default branch
-          type=raw,value=latest,enable={{is_default_branch}}
+        tags: 'type=raw,value={{date ''YYYY.MM''}},enable={{is_default_branch}}
+
+          type=raw,value=latest,enable={{is_default_branch}}'
     - name: login to docker.io registry
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/publish-on-push-to-main.yml
+++ b/.github/workflows/publish-on-push-to-main.yml
@@ -18,7 +18,11 @@ jobs:
         images: octodns/${{matrix.flavor}}
         labels: org.opencontainers.image.documentation=https://github.com/octodns/octodns#readme
           org.opencontainers.image.licenses=MIT
-        tags: type=raw,value={{date 'YYYY.MM'}} type=raw,value=latest,enable={{is_default_branch}}
+        tags: |
+          # monthly tagged release
+          type=raw,value={{date 'YYYY.MM'}},enable={{is_default_branch}}
+          # 'latest' tag if on default branch
+          type=raw,value=latest,enable={{is_default_branch}}
     - name: login to docker.io registry
       uses: docker/login-action@v3
       with:

--- a/script/generate-workflow-files
+++ b/script/generate-workflow-files
@@ -108,9 +108,9 @@ def write_publish_workflow(flavors):
                         'flavor': 'latest=false',
                         'tags': ''
                             # set dated tag
-                            'type=raw,value={{date \'YYYY.MM\'}}'
+                            'type=raw,value={{date \'YYYY.MM\'}},enable={{is_default_branch}}'
                             # set latest tag for default branch
-                            ' type=raw,value=latest,enable={{is_default_branch}}',
+                            '\ntype=raw,value=latest,enable={{is_default_branch}}',
                         'labels': ''
                             'org.opencontainers.image.documentation=https://github.com/octodns/octodns#readme'
                             ' org.opencontainers.image.licenses=MIT'


### PR DESCRIPTION
It appears this broke with the move to multi-arch workflow. I updated the syntax to fix this issue based on [some docker/metadata-action documentation](https://github.com/docker/metadata-action?tab=readme-ov-file#major-version-zero). I think the limitation might be the Python script which generates this.