### PR TITLE
fix: remove unnecessary apt packages bloating image size

### DIFF
--- a/all/Dockerfile
+++ b/all/Dockerfile
@@ -15,10 +15,6 @@ RUN set -ex; \
   fi
 
 RUN set -ex \
-  && apt-get update \
-  && apt-get install git build-essential libffi-dev rustc cargo --no-install-recommends -y \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && python -m venv env \
   && . env/bin/activate \
   && pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## context

I noticed that recent `octodns/octodns` images have become substantially larger (as shown below) and wanted to figure out why and if it was truly necessary.

```
❯ podman images
REPOSITORY                 TAG          IMAGE ID      CREATED         SIZE
localhost/octodns-local    latest       4c99f58af27f  18 minutes ago  254 MB
docker.io/library/python   3.13.5-slim  300924e3c7de  2 days ago      125 MB
docker.io/octodns/octodns  2025.03      360af9c17a79  2 months ago    1.04 GB
docker.io/octodns/octodns  2024.09      ed49e3dd1965  9 months ago    329 MB
```

I concluded that the multi-arch MR (see references) had added things like `build-essential` and `rustc` into the final image which was drastically increasing the final size (unsurprisingly), but I didn't think they were needed beyond build time or maybe at all. it's not explicitly stated from what I can tell, but I'm _guessing_ they were added back when `cryptography` first added in `rust` and had a few versions where `pip` wasn't properly pulling pre-compiled wheels, but hard to say for sure.

what I can say is that I _don't think_ that any of the build/compilation tools are actually needed with modern `python`/`pip` versions and current wheels, and I couldn't find anything explaining `git` or `libffi-dev` either, but don't hesitate to correct me if I'm wrong anywhere!

`localhost/octodns-local:latest` in the above codeblock is an example `linux/amd64` image I built from these changes showing the rough savings compared to the `octodns/octodns` images immediately preceding/following the multi-arch MR

## changes

- remove unnecessary `apt` packages bloating image size
    - reduction of roughly ~`70 MiB` on-disk compared to images before the multi-arch MR was merged
    - reduction of roughly ~`750 MiB` on-disk compared to images after the multi-arch MR was merged

## references

- #74