### PR TITLE
Include octodns-ddns and octodns-spf in all image

### DIFF
--- a/all/requirements.txt
+++ b/all/requirements.txt
@@ -3,6 +3,7 @@ octodns-azure==1.0.0
 octodns-bind==1.0.1
 octodns-cloudflare==1.0.0
 octodns-constellix==1.0.0
+octodns-ddns==0.2.1
 octodns-digitalocean==1.0.0
 octodns-dnsimple==1.0.0
 octodns-dnsmadeeasy==1.0.0
@@ -22,5 +23,6 @@ octodns-powerdns==1.0.0
 octodns-rackspace==1.0.0
 octodns-route53==1.0.1
 octodns-selectel==1.0.0
+octodns-spf==1.0.0
 octodns-transip==1.0.0
 octodns-ultra==1.0.0


### PR DESCRIPTION
Was playing around with the all image testing out https://github.com/octodns/octodns-docker/pull/191#pullrequestreview-2951366022 and realized a couple of "accessory" modules aren't included in the all image, namely the SPF and DDNS helpers.